### PR TITLE
Support .ll and .yy file extensions

### DIFF
--- a/grammars/language-bison-flex.cson
+++ b/grammars/language-bison-flex.cson
@@ -1,7 +1,9 @@
 fileTypes: [
 	'y',
 	'ypp',
+	'yy',
 	'l',
+	'll',
 	'lex',
 	'flex'
 ]


### PR DESCRIPTION
Could you please merge this PR that adds grammar support to `.ll` and `.yy` file extensions.

Those are standard extensions mentioned in the bison documentation, eg.

https://www.gnu.org/software/bison/manual/html_node/C_002b_002b-Bison-Interface.html#C_002b_002b-Bison-Interface

Thanks !

Pablo